### PR TITLE
Fix static directory creation.

### DIFF
--- a/lib/rackula/command/generate.rb
+++ b/lib/rackula/command/generate.rb
@@ -56,11 +56,14 @@ module Rackula
 						raise Samovar::Failure.new("Output path already exists!")
 					end
 				end
+
+				# Create output directory
+				Dir.mkdir(output_path)
 				
 				# Copy all public assets:
 				asset_pattern = root + @options[:public] + '*'
 				Dir.glob(asset_pattern.to_s).each do |path|
-					FileUtils.cp_r(path, output_path)
+					FileUtils.cp_r(path, File.join(output_path, "."))
 				end
 				
 				# Generate HTML pages:

--- a/spec/rackula_spec.rb
+++ b/spec/rackula_spec.rb
@@ -27,5 +27,6 @@ RSpec.describe Rackula do
 		
 		expect(File).to be_exist(File.join(output_path, "index.html"))
 		expect(File).to be_exist(File.join(output_path, "another.html"))
+		expect(File).to be_exist(File.join(output_path, "document.txt"))
 	end
 end

--- a/spec/site/public/document.txt
+++ b/spec/site/public/document.txt
@@ -1,0 +1,1 @@
+Test document.


### PR DESCRIPTION
Previously, the code would "cp -r" with each source file and the
destination path. When the (first) source file was not a directory,
it would overwrite the directory with that file.

This caused some errors later and left the static directory somewhat
broken.

It also creates the output directory.